### PR TITLE
Js my goals fix

### DIFF
--- a/Models/Goal.model.ts
+++ b/Models/Goal.model.ts
@@ -5,5 +5,5 @@ export interface Goal {
     weeklyGoal: WeeklyGoal,
     startWeight?: number,
     endWeight?: number,
-    achieved?: 'Yes' | 'No';
+    achieved?: boolean;
 }

--- a/Src/Logic/MyGoals/MyGoals.ts
+++ b/Src/Logic/MyGoals/MyGoals.ts
@@ -14,7 +14,7 @@ export function generateMyGoals(username: string): HTMLDivElement {
     'div',
     'my-goals-container',
   ) as HTMLDivElement;
-  const actualDate = new Date();
+  const actualDate = new Date(Date.now());
 
   const weeklyGoalComponent = generateWeeklyGoalComponent(
     actualDate.toLocaleDateString('en-GB'),
@@ -26,11 +26,18 @@ export function generateMyGoals(username: string): HTMLDivElement {
 
   function onSaveButtonClick(weeklyGoalValue: WeeklyGoal) {
     const user = readFromLocalStorage(username);
+    const currentWeight = user.weights[0].weight;
+    const previousGoal = user.goals[0];
+    previousGoal.endWeight=currentWeight;
     const newGoal: Goal = {
       date: actualDate,
       weeklyGoal: weeklyGoalValue,
+      startWeight:currentWeight
     };
+
     user.goals.unshift(newGoal);
+
+    previousGoal.achieved=checkIfGoalIsAchieved(previousGoal);
     saveInLocalStorage(username, user);
     const newhistoricalWeeklyGoalsTable = createHistoricalWeeklyGoalsTable(
       user.goals,
@@ -43,4 +50,18 @@ export function generateMyGoals(username: string): HTMLDivElement {
     RefreshProfileInfo(user);
   }
   return myGoalsContainer;
+}
+
+function checkIfGoalIsAchieved(goal: Goal): boolean{
+  const startWeight=goal.startWeight;
+  const endWeight=goal.endWeight;
+  if(goal.weeklyGoal===WeeklyGoal.Gain){
+  return endWeight>startWeight; 
+  }
+  else if(goal.weeklyGoal===WeeklyGoal.Lose){
+    return endWeight<startWeight;
+    }
+  else if(goal.weeklyGoal===WeeklyGoal.Keep){
+    return endWeight===startWeight;
+  }
 }

--- a/Src/Logic/Registration/Registration.ts
+++ b/Src/Logic/Registration/Registration.ts
@@ -40,7 +40,11 @@ export default function generateRegistrationForm(
       date: currentDate,
       weight: firstStepValues.currentWeight
     };
-    const goal:Goal={date:currentDate, weeklyGoal:secondStepValues.weeklyGoal}
+    const goal:Goal={
+      date:currentDate, 
+      weeklyGoal:secondStepValues.weeklyGoal,
+      startWeight:firstStepValues.currentWeight
+    }
     const user: User = {
       name: firstStepValues.name,
       gender: firstStepValues.gender,

--- a/Src/Logic/SaveWeightInLocalStorage/SaveWeightInLocalStorage.ts
+++ b/Src/Logic/SaveWeightInLocalStorage/SaveWeightInLocalStorage.ts
@@ -1,11 +1,12 @@
 import { User } from '../../../Models/User.model';
-import { saveInLocalStorage } from '../LocalStorage/LocalStorage';
+import { readFromLocalStorage, saveInLocalStorage } from '../LocalStorage/LocalStorage';
 import { refreshRemainingCalories } from '../SetRemainingCalories/SetRemainingCalories';
 import { generateGaugesContent } from '../../UIComponents/Overview/Overview';
 import { refreshMyWeightsComponent } from '../../UIComponents/MyWeights/MyWeights';
 import { RefreshProfileInfo } from '../SetProfileInfo/SetProfileInfo';
 
 export function saveWeightInLocalStorage(weight: number, date: Date, user:User){
+  user = readFromLocalStorage(user.name);
   user.weights.unshift({
     date: date,
     weight: weight

--- a/Src/UIComponents/HistoricalWeeklyGoalsTable/HistoricalWeeklyGoalsTable.ts
+++ b/Src/UIComponents/HistoricalWeeklyGoalsTable/HistoricalWeeklyGoalsTable.ts
@@ -1,11 +1,14 @@
 import { createTable, addRow } from '../ReusableTable/ReusableTable';
 import generateTileComponent from '../TileComponent/TileComponent';
 import { Goal } from '../../../Models/Goal.model';
-import {createElement} from '../../../Src/UIComponents/utils/utils';
+import { createElement } from '../../../Src/UIComponents/utils/utils';
 
 function createHistoricalWeeklyGoalsTable(tableData: Goal[]): HTMLDivElement {
-  const container = createElement('div',['historical-weekly-goals-table', 'tile-container']);
-  const title = createElement('p','tile-title');
+  const container = createElement('div', [
+    'historical-weekly-goals-table',
+    'tile-container',
+  ]);
+  const title = createElement('p', 'tile-title');
   const titleContent = document.createTextNode('Historical weekly goals');
   title.appendChild(titleContent);
   const tile = generateTileComponent(container);
@@ -21,18 +24,28 @@ function createHistoricalWeeklyGoalsTable(tableData: Goal[]): HTMLDivElement {
 
   for (let i = 0; i < tableData.length; i++) {
     const row = tableData[i];
-    const date=new Date(row.date);
+    const date = new Date(row.date);
+    
     const rowValues: string[] = [
       date.toLocaleDateString('en-GB'),
       row.weeklyGoal,
-      row.startWeight?`${row.startWeight}`:"",
-      row.endWeight? `${row.endWeight}`:"",
-      row.achieved?`${row.achieved}`:"",
+      row.startWeight ? `${row.startWeight}` : '',
+      row.endWeight ? `${row.endWeight}` : '',
+      calculateAchieved(row.achieved)
     ];
     addRowToHistoricalWeeklyGoalsTable(rowValues);
   }
   container.append(title, table);
   return tile;
+}
+function calculateAchieved(achieved?:boolean):string{
+  if (achieved === undefined) {
+    return '';
+  } else if (achieved) {
+    return 'Yes';
+  } else {
+    return 'No';
+  }
 }
 
 export { createHistoricalWeeklyGoalsTable };

--- a/Test/HistoricalWeeklyGoalsTable.test.ts
+++ b/Test/HistoricalWeeklyGoalsTable.test.ts
@@ -14,14 +14,14 @@ describe('Tests for createHistoricalWeeklyGoalsTable',()=>{
             weeklyGoal: WeeklyGoal.Gain,
             startWeight: 70,
             endWeight: 80,
-            achieved: 'Yes',
+            achieved: true,
           },
           {
             date: new Date(1994,12,18),
             weeklyGoal: WeeklyGoal.Lose,
             startWeight: 60,
             endWeight: 61,
-            achieved: 'No',
+            achieved: false,
           }]);
         expect(table).toMatchSnapshot();
     })

--- a/Test/MyGoals.test.ts
+++ b/Test/MyGoals.test.ts
@@ -5,9 +5,16 @@ import { User } from '../Models/User.model';
 import { WeeklyGoal } from '../Models/WeeklyGoal.model';
 import { Goal } from '../Models/Goal.model';
 import { ActivityLevel } from '../Models/ActivityLevel.model';
+import { Weight } from '../Models/Weight.model';
+
+
 
 describe('my goals tests', () => {
-  test('should rendered my gols component', () => {
+  beforeEach(()=>{
+    Date.now = jest.fn(() => new Date(2021, 2, 15).valueOf())
+  })
+  
+  test('should render my goals component', () => {
     const firstGoal: Goal = {
       date: new Date(),
       weeklyGoal: WeeklyGoal.Gain,
@@ -39,29 +46,131 @@ describe('my goals tests', () => {
       HistoricalWeeklyGoalsTable.createHistoricalWeeklyGoalsTable,
     ).toBeCalledWith(testUser.goals);
   });
-  test('should save to local storage on save', () => {
+  test('should create new goal, update previous as achieved and save to local storage', () => {
     const firstGoal: Goal = {
-      date: new Date(),
+      date: new Date(2021,2,8),
       weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 80
     };
+
+    const firstWeight: Weight={
+      date: new Date(2021,2,8),
+      weight: 80
+    }
+    const secondWeight: Weight={
+      date: new Date(2021,2,15),
+      weight: 85
+    }
 
     const testUser: User = {
       name: 'TestUser',
       gender: 'Male',
-      dateOfBirth: new Date(),
+      dateOfBirth: new Date(1995,7,7),
       height: 180,
       goalWeight: 90,
       activityLevel: ActivityLevel.Active,
       goals: [firstGoal],
+      weights:[secondWeight, firstWeight]
     };
     jest.spyOn(LocalStorage, 'readFromLocalStorage').mockReturnValue(testUser);
     jest.spyOn(LocalStorage, 'saveInLocalStorage').mockImplementation(jest.fn());
     const myGoalsComponent = generateMyGoals(testUser.name);
+
     const saveButton = myGoalsComponent.querySelector(
       '.button-save',
     ) as HTMLButtonElement;
 
     saveButton.click();
-    expect(LocalStorage.saveInLocalStorage).toBeCalledTimes(1);
+
+    const expectedUpdatedFirstGoal: Goal = {
+      date: new Date(2021,2,8),
+      weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 80,
+      endWeight:85,
+      achieved: true
+    };
+
+    const secondGoal: Goal = {
+      date: new Date(2021,2,15),
+      weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 85
+    };
+
+    const expectedUser: User = {
+    name: 'TestUser',
+    gender: 'Male',
+    dateOfBirth: new Date(1995,7,7),
+    height: 180,
+    goalWeight: 90,
+    activityLevel: ActivityLevel.Active,
+    goals: [secondGoal, expectedUpdatedFirstGoal],
+    weights:[secondWeight, firstWeight]}
+    
+    expect(LocalStorage.saveInLocalStorage).toBeCalledWith(expectedUser.name, expectedUser);
+
+  });
+
+  test('should create new goal, update previous as not achieved and save to local storage', () => {
+    const firstGoal: Goal = {
+      date: new Date(2021,2,8),
+      weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 80
+    };
+
+    const firstWeight: Weight={
+      date: new Date(2021,2,8),
+      weight: 80
+    }
+    const secondWeight: Weight={
+      date: new Date(2021,2,15),
+      weight: 75
+    }
+
+    const testUser: User = {
+      name: 'TestUser',
+      gender: 'Male',
+      dateOfBirth: new Date(1995,7,7),
+      height: 180,
+      goalWeight: 90,
+      activityLevel: ActivityLevel.Active,
+      goals: [firstGoal],
+      weights:[secondWeight, firstWeight]
+    };
+    jest.spyOn(LocalStorage, 'readFromLocalStorage').mockReturnValue(testUser);
+    jest.spyOn(LocalStorage, 'saveInLocalStorage').mockImplementation(jest.fn());
+    const myGoalsComponent = generateMyGoals(testUser.name);
+
+    const saveButton = myGoalsComponent.querySelector(
+      '.button-save',
+    ) as HTMLButtonElement;
+
+    saveButton.click();
+
+    const expectedUpdatedFirstGoal: Goal = {
+      date: new Date(2021,2,8),
+      weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 80,
+      endWeight:75,
+      achieved: false
+    };
+
+    const secondGoal: Goal = {
+      date: new Date(2021,2,15),
+      weeklyGoal: WeeklyGoal.Gain,
+      startWeight: 75
+    };
+
+    const expectedUser: User = {
+    name: 'TestUser',
+    gender: 'Male',
+    dateOfBirth: new Date(1995,7,7),
+    height: 180,
+    goalWeight: 90,
+    activityLevel: ActivityLevel.Active,
+    goals: [secondGoal, expectedUpdatedFirstGoal],
+    weights:[secondWeight, firstWeight]}
+    
+    expect(LocalStorage.saveInLocalStorage).toBeCalledWith(expectedUser.name, expectedUser);
+
   });
 });

--- a/Test/Overview.test.ts
+++ b/Test/Overview.test.ts
@@ -3,6 +3,7 @@ import { User } from '../Models/User.model';
 import { ActivityLevel } from '../Models/ActivityLevel.model';
 import { fn } from 'moment';
 import createGauge from '../Src/UIComponents/GoalTile/Gauges';
+import * as LocalStorage from '../Src/Logic/LocalStorage/LocalStorage';
 
 jest.mock('../Src/UIComponents/GoalTile/Gauges');
 
@@ -57,6 +58,7 @@ describe('Overview full component check', () => {
     })
     
     test('when data is inputted tiles change the values', () => {
+        jest.spyOn(LocalStorage,'readFromLocalStorage').mockReturnValue(dummyobject);
         const editButton = document.querySelector('section.my-weight-tile__button-section > button') as HTMLButtonElement;
         editButton.click();
 

--- a/Test/Registration.test.ts
+++ b/Test/Registration.test.ts
@@ -94,6 +94,7 @@ describe('registration tests', () => {
         {
           date: expect.any(Date),
           weeklyGoal: 'Gain',
+          startWeight: 80
         },
       ],
       height: 160,

--- a/Test/SetProfileInfo.test.ts
+++ b/Test/SetProfileInfo.test.ts
@@ -18,7 +18,7 @@ const user: User = {
     weeklyGoal: WeeklyGoal.Gain,
     startWeight: 66,
     endWeight: 68,
-    achieved: 'Yes'
+    achieved: true
   }],
   diaryFood: [
     new MyDiaryFood({

--- a/Test/Views.test.ts
+++ b/Test/Views.test.ts
@@ -22,7 +22,7 @@ const userObject: User = {
     weeklyGoal: WeeklyGoal.Gain,
     startWeight: 60,
     endWeight: 71,
-    achieved: 'No'
+    achieved: false
   }],
   weights: [{date: new Date(), weight: 60}]
 };


### PR DESCRIPTION
Podczas poprawiania tabeli z My Goals zauważyłam bug polegający na tym, że kiedy po dodaniu goalsów w My Goals przechodziło się do Overview i zapisywało nową wagę, następnie znów wchodziło się w myGoals i wybierało się nowy goal, to usuwały się niektóre wiersze z tabeli. Po sprawdzeniu innych komponentów okazało się, że taka sama sytuacja miała miejsce w sekcji My Diary. Okazało się, że problemem było to, że komponenty nie renderują się na nowo kiedy przechodzi się między opcjami menu, a jedynie zmieniają się z display:none na visible. Poprawiłam ten bug jak najmniejszym kosztem. W pliku saveWeightInLocalStorage w funkcji saveWeightInLocalStorage.  W tamtej funkcji przez brak updatowania usera, nie widział on zmian dokonanych w innych komponentach i ponowne przejście do nich skutkowało usunięciem wcześniej dodanych danych. 

Kroki do odtworzenia błędu na masterze:
1.Dodać kilka nowych goalsów, np. 4 w sekcji My Goals.
2.Przejść do Overview, zmienić wagę i ją zapisać. 
3. Przejść do sekcji My Goals i dodać kolejny goal (po dodaniu nowego goala rekordy znikają ze wzgledu na to, ze overview je nadpisuje w localStorage).
4. Powyższe kroki powodują usunięcie wcześniejszych wierszy z tabeli. 
5. Można w podobny sposób sprawdzić ten błąd w sekcji My Diary, usuwały się niektóre zapisane wcześniej produkty. 